### PR TITLE
Add default deployment config

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,10 @@
+# Adds namespace to all resources.
+namespace: appuio-cloud-agent
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../rbac
+- ../manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- manager.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: appuio-cloud-agent
+  namespace: appuio-cloud-agent
+  labels:
+    control-plane: appuio-cloud-agent
+spec:
+  selector:
+    matchLabels:
+      control-plane: appuio-cloud-agent
+  replicas: 3
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: agent
+      labels:
+        control-plane: appuio-cloud-agent
+    spec:
+      containers:
+      - command:
+        - appuio-cloud-agent
+        args:
+        - --leader-elect
+        image: ghcr.io/appuio/appuio-cloud-agent:latest
+        ports:
+        - containerPort: 9443
+        name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 128Mi
+      serviceAccountName: appuio-cloud-agent
+      terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
         image: ghcr.io/appuio/appuio-cloud-agent:latest
         ports:
         - containerPort: 9443
-        name: manager
+        name: agent
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: appuio-cloud-agent
+  name: appuio-cloud-agent

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,37 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: appuio-cloud-agent:leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appuio-cloud-agent:leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio-cloud-agent:leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: appuio-cloud-agent
+  namespace: appuio-cloud-agent

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio-cloud-agent
+subjects:
+- kind: ServiceAccount
+  name: appuio-cloud-agent
+  namespace: appuio-cloud-agent

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appuio-cloud-agent
+  namespace: appuio-cloud-agent

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: appuio-cloud-agent
+
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,18 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: appuio-cloud-agent
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: appuio-cloud-agent


### PR DESCRIPTION
## Summary

Adds some default k8s manifests we can use as a base for the component. See: https://github.com/appuio/component-appuio-cloud/pull/86

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
