### PR TITLE
Fix invalid warning with newline

### DIFF
--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -70,8 +70,11 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 	if r.Below(*v.RatioLimit) {
 		return admission.Response{
 			AdmissionResponse: admissionv1.AdmissionResponse{
-				Allowed:  true,
-				Warnings: []string{fmt.Sprintf("Current memory to CPU ratio of %s/core in this namespace is below the fair use ratio of %s/core\n This might lead to additional cost.", r, v.RatioLimit)},
+				Allowed: true,
+				// WARNING(glrf) Warnings MUST NOT contain newlines. K8s will simply drop your warning if you add newlines.
+				Warnings: []string{
+					fmt.Sprintf("Current memory to CPU ratio of %s/core in this namespace is below the fair use ratio of %s/core. This might lead to additional costs.", r, v.RatioLimit),
+				},
 			}}
 	}
 	return admission.Allowed("ok")

--- a/webhooks/ratio_validator_test.go
+++ b/webhooks/ratio_validator_test.go
@@ -226,6 +226,9 @@ func TestRatioValidator_Handle(t *testing.T) {
 			assert.True(t, resp.Allowed)
 			if tc.warn {
 				assert.NotEmpty(t, resp.AdmissionResponse.Warnings)
+				for _, w := range resp.AdmissionResponse.Warnings {
+					assert.NotContainsf(t, w, "\n", "Warning are not allowed to contain newlines")
+				}
 			} else {
 				assert.Empty(t, resp.AdmissionResponse.Warnings)
 			}


### PR DESCRIPTION
## Summary

K8s will silently drop warnings with newlines...

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
