### PR TITLE
Add annotation to disable request ration warnings per namespace

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,9 @@
 version: "2"
+checks:
+  return-statements:
+    enabled: true
+    config:
+      threshold: 8
 plugins:
   shellcheck:
     enabled: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/main.go
+++ b/main.go
@@ -22,12 +22,11 @@ var (
 	commit  = "-dirty-"
 	date    = time.Now().Format("2006-01-02")
 
-	// TODO: Adjust app name
 	appName     = "appuio-cloud-agent"
 	appLongName = "agent running on every APPUiO Cloud Zone"
 
 	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	setupLog = ctrl.Log.WithName("setup").WithValues("version", version, "commit", commit, "date", date)
 )
 
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen object paths="./..."

--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -126,7 +126,7 @@ func (v *RatioValidator) isNamespaceDisabled(ctx context.Context, nsName string)
 
 	disabled, ok := ns.Annotations[RatioValidatiorDisableAnnotation]
 	if !ok {
-		return false, err
+		return false, nil
 	}
 	return strconv.ParseBool(disabled)
 }

--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -20,6 +20,7 @@ import (
 )
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // RatioValidator checks for every action in a namespace whether the Memory to CPU ratio limit is exceeded and will return a warning if it is.
 type RatioValidator struct {

--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -68,7 +68,7 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 	// If we are creating an object with resource requests, we add them to the current ratio
 	// We cannot easily do this when updating resources.
 	if req.Operation == admissionv1.Create {
-		r, err = v.recodObject(ctx, r, req)
+		r, err = v.recordObject(ctx, r, req)
 		if err != nil {
 			l.Error(err, "failed to record object")
 			return errored(http.StatusBadRequest, err)
@@ -91,7 +91,7 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 	return admission.Allowed("ok")
 }
 
-func (v *RatioValidator) recodObject(ctx context.Context, r *Ratio, req admission.Request) (*Ratio, error) {
+func (v *RatioValidator) recordObject(ctx context.Context, r *Ratio, req admission.Request) (*Ratio, error) {
 	switch req.Kind.Kind {
 	case "Pod":
 		pod := corev1.Pod{}

--- a/webhooks/ratio_validator_test.go
+++ b/webhooks/ratio_validator_test.go
@@ -104,13 +104,14 @@ func TestRatioValidator_Handle(t *testing.T) {
 			user:      "bar",
 			namespace: "fail-bar",
 			resources: []client.Object{
+				testNamespace("fail-bar"),
 				podFromResources("pod1", "foo", podResource{
 					{cpu: "100m", memory: "3G"},
 				}),
 				podFromResources("pod2", "foo", podResource{
 					{cpu: "50m", memory: "1Gi"},
 				}),
-				podFromResources("unfair", "bar", podResource{
+				podFromResources("unfair", "fail-bar", podResource{
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
@@ -242,7 +243,7 @@ func prepareTest(t *testing.T, initObjs ...client.Object) *RatioValidator {
 
 	decoder, err := admission.NewDecoder(scheme)
 	require.NoError(t, err)
-
+	initObjs = append(initObjs, testNamespace("foo"), testNamespace("bar"))
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(initObjs...).
@@ -254,6 +255,14 @@ func prepareTest(t *testing.T, initObjs ...client.Object) *RatioValidator {
 	})
 	uv.InjectDecoder(decoder)
 	return uv
+}
+
+func testNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
 }
 
 func podFromResources(name, namespace string, res podResource) *corev1.Pod {


### PR DESCRIPTION
## Summary

Introduces an annotation to disable the request ratio webhook on a per namespace basis.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
