### PR TITLE
Round up ratios to next MiB

### DIFF
--- a/ratio/ratio_test.go
+++ b/ratio/ratio_test.go
@@ -193,6 +193,18 @@ func TestRatio_ratio(t *testing.T) {
 			ratio:       "0",
 			smallerThan: "1Mi",
 		},
+		{
+			// Ratio gets rounded up, exact result would be 1917396114 bytes
+			cpu:    "1.4",
+			memory: "2560Mi",
+			ratio:  "1829Mi",
+		},
+		{
+			// Ratio gets rounded up, exact result would be 400.5Mi
+			cpu:    "2",
+			memory: "801Mi",
+			ratio:  "401Mi",
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("[%s/%s=%s]", tc.memory, tc.cpu, tc.ratio), func(t *testing.T) {


### PR DESCRIPTION
## Summary

This improves the readability of the warning text for ratio which don't divide nicely.

For example, we now get a ratio of "1829Mi" for CPU requests of "1400m" and memory requests of "2560Mi" instead of the exact "1917396114" (in bytes).

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
