### PR TITLE
Add link to APPUiO Cloud pricing in warning text

### DIFF
--- a/ratio/ratio.go
+++ b/ratio/ratio.go
@@ -106,5 +106,6 @@ func (r Ratio) Warn(limit *resource.Quantity) string {
 		w = fmt.Sprintf("%s of %s/core", w, limit)
 	}
 	w = fmt.Sprintf("%s. APPUiO Cloud bills CPU requests which exceed the fair use ratio.", w)
+	w = fmt.Sprintf("%s See https://vs.hn/appuio-cloud-cpu-requests for instructions to adjust the requests.", w)
 	return w
 }


### PR DESCRIPTION
## Summary

* Add link to APPUiO Cloud product page in text of warning emitted for namespaces violating the zone's ratio.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
