### PR TITLE
Fix permission to be able to set owner references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,6 +23,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/controllers/org_rbac_controller.go
+++ b/controllers/org_rbac_controller.go
@@ -37,6 +37,9 @@ const LabelRoleBindingUninitialized = "appuio.io/uninitialized"
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;patch;update
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
+// We don't actually want or need to set finalizers, but if "OwnerReferencesPermissionEnforcement" is enabled we need this permission to set an owner reference to a namespace
+//+kubebuilder:rbac:groups="",resources=namespaces/finalizers,verbs=update
+
 // Reconcile makes sure the role bindings for the configured cluster roles are present in every organization namespace.
 // It will also update role bindings with the label "appuio.io/uninitialized": "true" to the default config.
 func (r *OrganizationRBACReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -100,8 +103,7 @@ func (r *OrganizationRBACReconciler) putRoleBinding(ctx context.Context, ns core
 			}
 			delete(rb.Labels, LabelRoleBindingUninitialized)
 		}
-		controllerutil.SetControllerReference(&ns, rb, r.Scheme)
-		return nil
+		return controllerutil.SetControllerReference(&ns, rb, r.Scheme)
 	})
 
 	return err


### PR DESCRIPTION
## Summary

To be able to set owner references we need permission to set finalizers 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
