### PR TITLE
Calculate ratio by node class

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/appuio/appuio-cloud-agent/limits"
 	"go.uber.org/multierr"
 	"sigs.k8s.io/yaml"
 )
@@ -12,8 +13,9 @@ type Config struct {
 	// OrganizationLabel is the label used to mark namespaces to belong to an organization
 	OrganizationLabel string
 
-	// MemoryPerCoreLimit is the fair use limit of memory usage per CPU core
-	MemoryPerCoreLimit string
+	// MemoryPerCoreLimits is the fair use limit of memory usage per CPU core
+	// It is possible to select limits by node selector labels
+	MemoryPerCoreLimits limits.Limits
 
 	// Privileged* is a list of the given type allowed to bypass restrictions.
 	// Wildcards are supported (e.g. "system:serviceaccount:default:*" or "cluster-*-operator").
@@ -49,9 +51,6 @@ func (c Config) Validate() error {
 
 	if c.OrganizationLabel == "" {
 		errs = append(errs, errors.New("OrganizationLabel must not be empty"))
-	}
-	if c.MemoryPerCoreLimit == "" {
-		errs = append(errs, errors.New("MemoryPerCoreLimit must not be empty"))
 	}
 
 	return multierr.Combine(errs...)

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,16 @@
 ---
 # The label used to mark namespaces to belong to an organization
 OrganizationLabel: appuio.io/organization
-# The fair use limit of memory usage per CPU core
-MemoryPerCoreLimit: 4Gi
+
+# The fair use limit of memory usage per CPU core.
+# It is possible to select limits by node selector labels.
+MemoryPerCoreLimits:
+- Limit: 4Gi
+  NodeSelector:
+    matchExpressions:
+      - key: class
+        operator: DoesNotExist
+
 # Privileged* is a list of the given type allowed to bypass restrictions.
 # Wildcards are supported (e.g. "system:serviceaccount:default:*" or "cluster-*-operator").
 # ClusterRoles are only ever matched if they are bound through a ClusterRoleBinding,

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func Test_Config_MemoryPerCoreLimit(t *testing.T) {
+	raw := `
+MemoryPerCoreLimits:
+- NodeSelector:
+    matchExpressions:
+      - key: class
+        operator: DoesNotExist
+  Limit: 7Gi
+`
+
+	var c Config
+	err := yaml.Unmarshal([]byte(raw), &c, yaml.DisallowUnknownFields)
+	require.NoError(t, err)
+
+	assert.Equal(t, "7Gi", c.MemoryPerCoreLimits[0].Limit.String())
+	assert.Equal(t, metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "class",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},
+		},
+	}, c.MemoryPerCoreLimits[0].NodeSelector)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,35 +1,84 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
-func Test_Config_MemoryPerCoreLimit(t *testing.T) {
-	raw := `
+const limitsYAML = `
 MemoryPerCoreLimits:
 - NodeSelector:
     matchExpressions:
       - key: class
         operator: DoesNotExist
-  Limit: 7Gi
+  Limit: 2Gi
+`
+const limitYAML = `
+MemoryPerCoreLimit: 1Gi
 `
 
-	var c Config
-	err := yaml.Unmarshal([]byte(raw), &c, yaml.DisallowUnknownFields)
-	require.NoError(t, err)
-
-	assert.Equal(t, "7Gi", c.MemoryPerCoreLimits[0].Limit.String())
-	assert.Equal(t, metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      "class",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
+func Test_Config_MemoryPerCoreLimits(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		yaml         string
+		warnings     int
+		limit        string
+		nodeSelector metav1.LabelSelector
+	}{
+		{
+			desc:     "MemoryPerCoreLimits",
+			yaml:     limitsYAML,
+			warnings: 0,
+			limit:    "2Gi",
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "class",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+				},
 			},
 		},
-	}, c.MemoryPerCoreLimits[0].NodeSelector)
+		{
+			desc:         "MemoryPerCoreLimit_Migrate",
+			yaml:         limitYAML,
+			warnings:     1,
+			limit:        "1Gi",
+			nodeSelector: metav1.LabelSelector{},
+		},
+		{
+			desc:     "MemoryPerCoreLimit_NoMigrateIfMemoryPerCoreLimitsIsSet",
+			yaml:     strings.Join([]string{limitsYAML, limitYAML}, "\n"),
+			warnings: 0,
+			limit:    "2Gi",
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "class",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			tmp := t.TempDir()
+			configPath := filepath.Join(tmp, "config.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte(tC.yaml), 0o644))
+
+			c, warnings, err := ConfigFromFile(configPath)
+			assert.Len(t, warnings, tC.warnings)
+			require.NoError(t, err)
+
+			assert.Equal(t, tC.limit, c.MemoryPerCoreLimits[0].Limit.String())
+			assert.Equal(t, tC.nodeSelector, c.MemoryPerCoreLimits[0].NodeSelector)
+		})
+	}
 }

--- a/controllers/ratio_controller_test.go
+++ b/controllers/ratio_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/appuio/appuio-cloud-agent/limits"
 	"github.com/appuio/appuio-cloud-agent/ratio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -169,7 +170,11 @@ func prepareRatioTest(t *testing.T, cfg testRatioCfg) *RatioReconciler {
 				Memory: cfg.fetchMemory.AsDec(),
 			},
 			}},
-		RatioLimit: &cfg.limit,
+		RatioLimits: limits.Limits{
+			{
+				Limit: &cfg.limit,
+			},
+		},
 	}
 }
 

--- a/controllers/ratio_controller_test.go
+++ b/controllers/ratio_controller_test.go
@@ -164,22 +164,22 @@ func prepareRatioTest(t *testing.T, cfg testRatioCfg) *RatioReconciler {
 		Scheme:   scheme,
 		Ratio: fakeRatioFetcher{
 			err: cfg.fetchErr,
-			ratio: &ratio.Ratio{
+			ratios: map[string]*ratio.Ratio{"": {
 				CPU:    cfg.fetchCPU.AsDec(),
 				Memory: cfg.fetchMemory.AsDec(),
 			},
-		},
+			}},
 		RatioLimit: &cfg.limit,
 	}
 }
 
 type fakeRatioFetcher struct {
-	err   error
-	ratio *ratio.Ratio
+	err    error
+	ratios map[string]*ratio.Ratio
 }
 
-func (f fakeRatioFetcher) FetchRatio(ctx context.Context, ns string) (*ratio.Ratio, error) {
-	return f.ratio, f.err
+func (f fakeRatioFetcher) FetchRatios(ctx context.Context, ns string) (map[string]*ratio.Ratio, error) {
+	return f.ratios, f.err
 }
 
 var testNs = &corev1.Namespace{

--- a/limits/limits.go
+++ b/limits/limits.go
@@ -1,0 +1,32 @@
+package limits
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Limit struct {
+	NodeSelector metav1.LabelSelector
+	Limit        *resource.Quantity
+}
+
+type Limits []Limit
+
+// GetLimitForNodeSelector returns the first limit that matches the given node selector.
+// If no limit matches, an empty string is returned.
+// Limits with invalid node selectors are ignored.
+func (l Limits) GetLimitForNodeSelector(nodeSelector map[string]string) *resource.Quantity {
+	for _, limit := range l {
+		limitSel, err := metav1.LabelSelectorAsSelector(&limit.NodeSelector)
+		if err != nil {
+			continue
+		}
+
+		if limitSel.Matches(labels.Set(nodeSelector)) {
+			return limit.Limit
+		}
+	}
+
+	return nil
+}

--- a/limits/limits_test.go
+++ b/limits/limits_test.go
@@ -1,0 +1,81 @@
+package limits_test
+
+import (
+	"testing"
+
+	"github.com/appuio/appuio-cloud-agent/limits"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetLimitForNodeSelector(t *testing.T) {
+	subject := limits.Limits{
+		{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "class",
+						Operator: "Invalid",
+					},
+				},
+			},
+			Limit: requireParseQuantity(t, "7Gi"),
+		},
+		{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "class",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+				},
+			},
+			Limit: requireParseQuantity(t, "7Gi"),
+		},
+		{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "class",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"highmem"},
+					},
+				},
+			},
+			Limit: requireParseQuantity(t, "14Gi"),
+		},
+		{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "gpu",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"tesla"},
+					},
+				},
+			},
+			Limit: requireParseQuantity(t, "2Gi"),
+		},
+	}
+
+	assert.Equal(t, "7Gi", subject.GetLimitForNodeSelector(map[string]string{}).String())
+	assert.Equal(t, "7Gi", subject.GetLimitForNodeSelector(map[string]string{"blubber": "blubber"}).String())
+
+	assert.Equal(t, "14Gi", subject.GetLimitForNodeSelector(map[string]string{"class": "highmem"}).String())
+	assert.Equal(t, "14Gi", subject.GetLimitForNodeSelector(map[string]string{"class": "highmem", "blubber": "blubber"}).String())
+	// First match wins
+	assert.Equal(t, "14Gi", subject.GetLimitForNodeSelector(map[string]string{"class": "highmem", "gpu": "tesla"}).String())
+
+	assert.Equal(t, "2Gi", subject.GetLimitForNodeSelector(map[string]string{"class": "other", "gpu": "tesla"}).String())
+
+	assert.Nil(t, subject.GetLimitForNodeSelector(map[string]string{"class": "other", "gpu": "other"}))
+}
+
+func requireParseQuantity(t *testing.T, s string) *resource.Quantity {
+	t.Helper()
+	q, err := resource.ParseQuantity(s)
+	require.NoError(t, err)
+	return &q
+}

--- a/limits/limits_test.go
+++ b/limits/limits_test.go
@@ -3,11 +3,12 @@ package limits_test
 import (
 	"testing"
 
-	"github.com/appuio/appuio-cloud-agent/limits"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/appuio/appuio-cloud-agent/limits"
 )
 
 func TestGetLimitForNodeSelector(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -56,10 +56,13 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	conf, err := ConfigFromFile(*configFilePath)
+	conf, warnings, err := ConfigFromFile(*configFilePath)
 	if err != nil {
 		setupLog.Error(err, "unable to read config file")
 		os.Exit(1)
+	}
+	for _, warning := range warnings {
+		setupLog.Info("WARNING " + warning)
 	}
 	if err := conf.Validate(); err != nil {
 		setupLog.Error(err, "invalid configuration")

--- a/ratio/fetcher.go
+++ b/ratio/fetcher.go
@@ -23,7 +23,7 @@ type Fetcher struct {
 	OrganizationLabel string
 }
 
-// FetchRatio collects the CPU to memory request ratio for the given namespace
+// FetchRatios collects the CPU to memory request ratio for the given namespace grouped by `.spec.nodeSelector`.
 func (f Fetcher) FetchRatios(ctx context.Context, name string) (map[string]*Ratio, error) {
 	ns := corev1.Namespace{}
 	err := f.Client.Get(ctx, client.ObjectKey{

--- a/ratio/fetcher.go
+++ b/ratio/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,7 +24,7 @@ type Fetcher struct {
 }
 
 // FetchRatio collects the CPU to memory request ratio for the given namespace
-func (f Fetcher) FetchRatio(ctx context.Context, name string) (*Ratio, error) {
+func (f Fetcher) FetchRatios(ctx context.Context, name string) (map[string]*Ratio, error) {
 	ns := corev1.Namespace{}
 	err := f.Client.Get(ctx, client.ObjectKey{
 		Name: name,
@@ -46,11 +47,21 @@ func (f Fetcher) FetchRatio(ctx context.Context, name string) (*Ratio, error) {
 		}
 	}
 
-	r := NewRatio()
 	pods := corev1.PodList{}
 	err = f.Client.List(ctx, &pods, client.InNamespace(name))
 	if err != nil {
-		return r, err
+		return nil, err
 	}
-	return r.RecordPod(pods.Items...), nil
+
+	ratios := make(map[string]*Ratio)
+	for _, pod := range pods.Items {
+		k := labels.Set(pod.Spec.NodeSelector).String()
+		r, ok := ratios[k]
+		if !ok {
+			r = NewRatio()
+		}
+		ratios[k] = r.RecordPod(pod)
+	}
+
+	return ratios, nil
 }

--- a/ratio/ratio.go
+++ b/ratio/ratio.go
@@ -102,9 +102,13 @@ func (r Ratio) String() string {
 }
 
 // Warn returns a warning string explaining that the ratio is not considered fair use
-func (r Ratio) Warn(limit *resource.Quantity) string {
+func (r Ratio) Warn(limit *resource.Quantity, nodeSelector string) string {
 	// WARNING(glrf) Warnings MUST NOT contain newlines. K8s will simply drop your warning if you add newlines.
-	w := fmt.Sprintf("Current memory to CPU ratio of %s/core in this namespace is below the fair use ratio", r.String())
+	w := fmt.Sprintf("Current memory to CPU ratio of %s/core", r.String())
+	if nodeSelector != "" {
+		w = fmt.Sprintf("%s for node type %q", w, nodeSelector)
+	}
+	w = fmt.Sprintf("%s in this namespace is below the fair use ratio", w)
 	if limit != nil {
 		w = fmt.Sprintf("%s of %s/core", w, limit)
 	}

--- a/ratio/ratio_test.go
+++ b/ratio/ratio_test.go
@@ -8,8 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestRatio_Record(t *testing.T) {
@@ -313,32 +311,4 @@ func FuzzRatio(f *testing.F) {
 			r.Below(lim)
 		})
 	})
-}
-
-func TestFormatLabel(t *testing.T) {
-	assert.Equal(t, "a=a,b=b", labels.FormatLabels(map[string]string{"b": "b", "a": "a"}))
-	assert.Equal(t, "<none>", labels.FormatLabels(nil))
-	assert.Equal(t, "<none>", labels.FormatLabels(map[string]string{}))
-
-	assert.Equal(t, "a=a,b=b", labels.Set{"b": "b", "a": "a"}.String())
-	assert.Equal(t, "", labels.Set{}.String())
-
-	assert.Equal(t, "a=a,b=b", labels.Set{"b": "b", "a": "a"}.AsSelector().String())
-	assert.Equal(t, "", labels.Set{}.AsSelector().String())
-}
-
-func TestMatchExpression(t *testing.T) {
-	lblSel := metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      "foo",
-				Operator: metav1.LabelSelectorOpDoesNotExist,
-			},
-		},
-	}
-	selector, err := metav1.LabelSelectorAsSelector(&lblSel)
-	assert.NoError(t, err)
-
-	assert.True(t, selector.Matches(labels.Set{"bar": "baz"}))
-	assert.False(t, selector.Matches(labels.Set{"foo": "baz"}))
 }

--- a/ratio/ratio_test.go
+++ b/ratio/ratio_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestRatio_Record(t *testing.T) {
@@ -311,4 +312,16 @@ func FuzzRatio(f *testing.F) {
 			r.Below(lim)
 		})
 	})
+}
+
+func TestFormatLabel(t *testing.T) {
+	assert.Equal(t, "a=a,b=b", labels.FormatLabels(map[string]string{"b": "b", "a": "a"}))
+	assert.Equal(t, "<none>", labels.FormatLabels(nil))
+	assert.Equal(t, "<none>", labels.FormatLabels(map[string]string{}))
+
+	assert.Equal(t, "a=a,b=b", labels.Set{"b": "b", "a": "a"}.String())
+	assert.Equal(t, "", labels.Set{}.String())
+
+	assert.Equal(t, "a=a,b=b", labels.Set{"b": "b", "a": "a"}.AsSelector().String())
+	assert.Equal(t, "", labels.Set{}.AsSelector().String())
 }

--- a/ratio/ratio_test.go
+++ b/ratio/ratio_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -324,4 +325,20 @@ func TestFormatLabel(t *testing.T) {
 
 	assert.Equal(t, "a=a,b=b", labels.Set{"b": "b", "a": "a"}.AsSelector().String())
 	assert.Equal(t, "", labels.Set{}.AsSelector().String())
+}
+
+func TestMatchExpression(t *testing.T) {
+	lblSel := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "foo",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},
+		},
+	}
+	selector, err := metav1.LabelSelectorAsSelector(&lblSel)
+	assert.NoError(t, err)
+
+	assert.True(t, selector.Matches(labels.Set{"bar": "baz"}))
+	assert.False(t, selector.Matches(labels.Set{"foo": "baz"}))
 }

--- a/ratio/ratio_test.go
+++ b/ratio/ratio_test.go
@@ -288,9 +288,11 @@ func TestRatio_Warn(t *testing.T) {
 		CPU:    cpu.AsDec(),
 		Memory: memory.AsDec(),
 	}
-	assert.Contains(t, r.Warn(nil), "1Gi")
+	assert.Contains(t, r.Warn(nil, ""), "1Gi")
 	lim := resource.MustParse("1Mi")
-	assert.Contains(t, r.Warn(&lim), "1Mi")
+	assert.Contains(t, r.Warn(&lim, ""), "1Mi")
+
+	assert.Contains(t, r.Warn(&lim, "class=x"), "class=x")
 }
 
 func FuzzRatio(f *testing.F) {
@@ -305,7 +307,7 @@ func FuzzRatio(f *testing.F) {
 				Memory: memQuant.AsDec(),
 			}
 			lim := resource.MustParse(fmt.Sprintf("%dMi", limit))
-			out := r.Warn(&lim)
+			out := r.Warn(&lim, "")
 			assert.NotEmpty(t, out)
 
 			r.Below(lim)

--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -119,7 +119,7 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 
 		if r.Below(*limit) {
 			l.Info("ratio too low", "node_selector", nodeSel, "ratio", r)
-			warnings = append(warnings, r.Warn(limit))
+			warnings = append(warnings, r.Warn(limit, nodeSel))
 		}
 	}
 

--- a/webhooks/ratio_validator.go
+++ b/webhooks/ratio_validator.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -32,7 +33,7 @@ type RatioValidator struct {
 }
 
 type ratioFetcher interface {
-	FetchRatio(ctx context.Context, ns string) (*ratio.Ratio, error)
+	FetchRatios(ctx context.Context, ns string) (map[string]*ratio.Ratio, error)
 }
 
 // Handle handles the admission requests
@@ -48,7 +49,7 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Allowed("system user")
 	}
 
-	r, err := v.Ratio.FetchRatio(ctx, req.Namespace)
+	ratios, err := v.Ratio.FetchRatios(ctx, req.Namespace)
 	if err != nil {
 		if errors.Is(err, ratio.ErrorDisabled) {
 			l.V(1).Info("allowed: namespace disabled")
@@ -62,30 +63,44 @@ func (v *RatioValidator) Handle(ctx context.Context, req admission.Request) admi
 		return errored(http.StatusInternalServerError, err)
 	}
 
-	l = l.WithValues("current_ratio", r.String())
+	nodeSel, err := v.getNodeSelector(req)
+	if err != nil {
+		l.Error(err, "failed to get node selector")
+		return errored(http.StatusBadRequest, err)
+	}
+
+	l = l.WithValues("current_ratios", ratios, "node_selector", nodeSel)
 	// If we are creating an object with resource requests, we add them to the current ratio
 	// We cannot easily do this when updating resources.
 	if req.Operation == admissionv1.Create {
+		r := ratios[labels.Set(nodeSel).String()]
+		if r == nil {
+			r = ratio.NewRatio()
+		}
 		r, err = v.recordObject(ctx, r, req)
 		if err != nil {
 			l.Error(err, "failed to record object")
 			return errored(http.StatusBadRequest, err)
 		}
-	}
-	l = l.WithValues("ratio", r.String())
+		ratios[labels.Set(nodeSel).String()] = r
 
-	if r.Below(*v.RatioLimit) {
-		l.Info("warned: ratio too low")
-		return admission.Response{
-			AdmissionResponse: admissionv1.AdmissionResponse{
-				Allowed: true,
-				Warnings: []string{
-					r.Warn(v.RatioLimit),
-				},
-			}}
+		l = l.WithValues("ratio", r)
 	}
-	l.V(1).Info("allowed: ratio ok")
-	return admission.Allowed("ok")
+
+	warnings := make([]string, 0, len(ratios))
+	for nodeSel, r := range ratios {
+		if r.Below(*v.RatioLimit) {
+			l.Info("ratio too low", "node_selector", nodeSel, "ratio", r)
+			warnings = append(warnings, r.Warn(v.RatioLimit))
+		}
+	}
+
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed:  true,
+			Warnings: warnings,
+		},
+	}
 }
 
 func (v *RatioValidator) recordObject(ctx context.Context, r *ratio.Ratio, req admission.Request) (*ratio.Ratio, error) {
@@ -110,6 +125,30 @@ func (v *RatioValidator) recordObject(ctx context.Context, r *ratio.Ratio, req a
 		r = r.RecordStatefulSet(sts)
 	}
 	return r, nil
+}
+
+func (v *RatioValidator) getNodeSelector(req admission.Request) (map[string]string, error) {
+	switch req.Kind.Kind {
+	case "Pod":
+		pod := corev1.Pod{}
+		if err := v.decoder.Decode(req, &pod); err != nil {
+			return nil, err
+		}
+		return pod.Spec.NodeSelector, nil
+	case "Deployment":
+		deploy := appsv1.Deployment{}
+		if err := v.decoder.Decode(req, &deploy); err != nil {
+			return nil, err
+		}
+		return deploy.Spec.Template.Spec.NodeSelector, nil
+	case "StatefulSet":
+		sts := appsv1.StatefulSet{}
+		if err := v.decoder.Decode(req, &sts); err != nil {
+			return nil, err
+		}
+		return sts.Spec.Template.Spec.NodeSelector, nil
+	}
+	return nil, nil
 }
 
 func errored(code int32, err error) admission.Response {

--- a/webhooks/ratio_validator_test.go
+++ b/webhooks/ratio_validator_test.go
@@ -40,7 +40,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 		object       client.Object
 		mangleObject bool
 		create       bool
-		limit        string
+		limits       limits.Limits
 		warn         bool
 		fail         bool
 		statusCode   int32
@@ -49,7 +49,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 		"Allow_EmptyNamespace": {
 			user:      "appuio#foo",
 			namespace: "foo",
-			limit:     "4Gi",
+			limits:    limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:      false,
 		},
 		"Allow_FairNamespace": {
@@ -66,8 +66,8 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "5", memory: "1Gi"},
 				}),
 			},
-			limit: "4Gi",
-			warn:  false,
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
+			warn:   false,
 		},
 		"Warn_UnfairNamespace": {
 			user:      "appuio#foo",
@@ -83,8 +83,31 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
-			limit: "1Gi",
-			warn:  true,
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
+			warn:   true,
+		},
+		"Warn_UnfairNamespace_Selectors": {
+			user:      "appuio#foo",
+			namespace: "foo",
+			resources: []client.Object{
+				podFromResources("fair", "foo", podResource{
+					{cpu: "1", memory: "4Gi"},
+				}, func(p *corev1.Pod) {
+					p.Spec.NodeSelector = map[string]string{"class": "foo"}
+				}),
+				podFromResources("unfair", "foo", podResource{
+					{cpu: "2", memory: "1Gi"},
+				}, func(p *corev1.Pod) {
+					p.Spec.NodeSelector = map[string]string{"class": "bar"}
+				}),
+			},
+			limits: limits.Limits{{
+				NodeSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"class": "bar"},
+				},
+				Limit: requireParseQuantity(t, "1Gi"),
+			}},
+			warn: true,
 		},
 		"Allow_DisabledUnfairNamespace": {
 			user:      "appuio#foo",
@@ -94,8 +117,8 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
-			limit: "1Gi",
-			warn:  false,
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
+			warn:   false,
 		},
 		"Allow_LowercaseDisabledUnfairNamespace": {
 			user:      "appuio#foo",
@@ -105,8 +128,8 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
-			limit: "1Gi",
-			warn:  false,
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
+			warn:   false,
 		},
 
 		"Allow_ServiceAccount": {
@@ -123,8 +146,8 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
-			limit: "1Gi",
-			warn:  false,
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
+			warn:   false,
 		},
 		"ListFailure": {
 			user:      "bar",
@@ -141,7 +164,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 					{cpu: "8", memory: "1Gi"},
 				}),
 			},
-			limit:      "1Gi",
+			limits:     limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
 			warn:       false,
 			fail:       true,
 			statusCode: http.StatusInternalServerError,
@@ -150,7 +173,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 			user:       "bar",
 			namespace:  "notexits",
 			resources:  []client.Object{},
-			limit:      "1Gi",
+			limits:     limits.Limits{{Limit: requireParseQuantity(t, "1Gi")}},
 			warn:       false,
 			fail:       true,
 			statusCode: http.StatusNotFound,
@@ -170,7 +193,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 			object: podFromResources("unfair", "foo", podResource{
 				{cpu: "8", memory: "1Gi"},
 			}),
-			limit:  "4Gi",
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:   true,
 			create: true,
 		},
@@ -182,24 +205,62 @@ func TestRatioValidator_Handle(t *testing.T) {
 				{cpu: "8", memory: "1Gi"},
 			}),
 			mangleObject: true,
-			limit:        "4Gi",
+			limits:       limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:         false,
 			create:       true,
 			fail:         true,
 			statusCode:   http.StatusBadRequest,
 		},
-		"Warn_ConsiderNewDeployment": {
+		"Warn_ConsiderNewDeployment_EmptyNS": {
+			user:      "appuio#foo",
+			namespace: "foo",
+			resources: []client.Object{},
+			object: deploymentFromResources("unfair", "foo", 2, podResource{
+				{cpu: "2", memory: "1Gi"},
+			}),
+			limits: limits.Limits{{
+				Limit: requireParseQuantity(t, "1Gi"),
+			}},
+			warn:   true,
+			create: true,
+		},
+		"Warn_ConsiderNewDeployment_NodeSelectorFromNamespace": {
+			user:      "appuio#foo",
+			namespace: "ns-with-default-node-selector",
+			resources: []client.Object{},
+			object: deploymentFromResources("ns-with-default-node-selector", "foo", 2, podResource{
+				{cpu: "2", memory: "1Gi"},
+			}),
+			limits: limits.Limits{{
+				NodeSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"class": "plus"},
+				},
+				Limit: requireParseQuantity(t, "1Gi"),
+			}},
+			warn:   true,
+			create: true,
+		},
+		"Warn_ConsiderNewDeployment_FuzzyMatchNodeSelector": {
 			user:      "appuio#foo",
 			namespace: "foo",
 			resources: []client.Object{
 				podFromResources("pod1", "foo", podResource{
-					{cpu: "0", memory: "4Gi"},
+					{cpu: "1", memory: "1Gi"},
+				}, func(p *corev1.Pod) {
+					p.Spec.NodeSelector = map[string]string{"app": "true", "class": "foo"}
 				}),
 			},
 			object: deploymentFromResources("unfair", "foo", 2, podResource{
-				{cpu: "1", memory: "1Gi"},
+				{cpu: "2", memory: "1Gi"},
+			}, func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.NodeSelector = map[string]string{"class": "foo"}
 			}),
-			limit:  "4Gi",
+			limits: limits.Limits{{
+				NodeSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "true"},
+				},
+				Limit: requireParseQuantity(t, "1Gi"),
+			}},
 			warn:   true,
 			create: true,
 		},
@@ -209,7 +270,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 			resources:    []client.Object{},
 			object:       deploymentFromResources("unfair", "foo", 2, podResource{}),
 			mangleObject: true,
-			limit:        "4Gi",
+			limits:       limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:         false,
 			create:       true,
 			fail:         true,
@@ -226,7 +287,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 			object: statefulsetFromResources("unfair", "foo", 2, podResource{
 				{cpu: "1", memory: "1Gi"},
 			}),
-			limit:  "4Gi",
+			limits: limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:   true,
 			create: true,
 		},
@@ -236,7 +297,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 			resources:    []client.Object{},
 			object:       statefulsetFromResources("unfair", "foo", 2, podResource{}),
 			mangleObject: true,
-			limit:        "4Gi",
+			limits:       limits.Limits{{Limit: requireParseQuantity(t, "4Gi")}},
 			warn:         false,
 			create:       true,
 			fail:         true,
@@ -245,10 +306,12 @@ func TestRatioValidator_Handle(t *testing.T) {
 	}
 
 	for name, tc := range tests {
+		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			v := prepareTest(t, tc.resources...)
-			limit := resource.MustParse(tc.limit)
-			v.RatioLimits = limits.Limits{{Limit: &limit}}
+			v.RatioLimits = tc.limits
 
 			ar := admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
@@ -316,6 +379,8 @@ func TestRatioValidator_Handle(t *testing.T) {
 }
 
 func prepareTest(t *testing.T, initObjs ...client.Object) *RatioValidator {
+	const defaultNodeSelectorAnnotation = "test.io/node-selector"
+
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -335,13 +400,22 @@ func prepareTest(t *testing.T, initObjs ...client.Object) *RatioValidator {
 		ratio.RatioValidatiorDisableAnnotation: "true",
 	}
 
-	initObjs = append(initObjs, testNamespace("foo"), barNs, disabledNs, otherDisabledNs)
+	nsWithDefaultNodeSelector := testNamespace("ns-with-default-node-selector")
+	nsWithDefaultNodeSelector.Annotations = map[string]string{
+		defaultNodeSelectorAnnotation: "class=plus",
+	}
+
+	initObjs = append(initObjs, testNamespace("foo"), barNs, disabledNs, otherDisabledNs, nsWithDefaultNodeSelector)
 	client := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(initObjs...).
 		Build()
 
 	uv := &RatioValidator{
+		DefaultNamespaceNodeSelectorAnnotation: defaultNodeSelectorAnnotation,
+
+		Client: failingClient{client},
+
 		Ratio: ratio.Fetcher{
 			Client: failingClient{client},
 		},
@@ -358,7 +432,7 @@ func testNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func podFromResources(name, namespace string, res podResource) *corev1.Pod {
+func podFromResources(name, namespace string, res podResource, modify ...func(*corev1.Pod)) *corev1.Pod {
 	p := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -387,10 +461,15 @@ func podFromResources(name, namespace string, res podResource) *corev1.Pod {
 		}
 		p.Spec.Containers = append(p.Spec.Containers, c)
 	}
+
+	for _, m := range modify {
+		m(&p)
+	}
+
 	return &p
 }
 
-func deploymentFromResources(name, namespace string, replicas int32, res podResource) *appsv1.Deployment {
+func deploymentFromResources(name, namespace string, replicas int32, res podResource, modify ...func(*appsv1.Deployment)) *appsv1.Deployment {
 	deploy := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -403,9 +482,15 @@ func deploymentFromResources(name, namespace string, replicas int32, res podReso
 	}
 	deploy.Spec.Replicas = &replicas
 	deploy.Spec.Template.Spec.Containers = newTestContainers(res)
+
+	for _, m := range modify {
+		m(&deploy)
+	}
+
 	return &deploy
 }
-func statefulsetFromResources(name, namespace string, replicas int32, res podResource) *appsv1.StatefulSet {
+
+func statefulsetFromResources(name, namespace string, replicas int32, res podResource, modify ...func(*appsv1.StatefulSet)) *appsv1.StatefulSet {
 	sts := appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
@@ -418,6 +503,11 @@ func statefulsetFromResources(name, namespace string, replicas int32, res podRes
 	}
 	sts.Spec.Replicas = &replicas
 	sts.Spec.Template.Spec.Containers = newTestContainers(res)
+
+	for _, m := range modify {
+		m(&sts)
+	}
+
 	return &sts
 }
 
@@ -459,4 +549,11 @@ func (c failingClient) List(ctx context.Context, list client.ObjectList, opts ..
 		return apierrors.NewInternalError(errors.New("ups"))
 	}
 	return c.WithWatch.List(ctx, list, opts...)
+}
+
+func requireParseQuantity(t *testing.T, s string) *resource.Quantity {
+	t.Helper()
+	q, err := resource.ParseQuantity(s)
+	require.NoError(t, err)
+	return &q
 }

--- a/webhooks/ratio_validator_test.go
+++ b/webhooks/ratio_validator_test.go
@@ -439,10 +439,6 @@ func newTestContainers(res []containerResources) []corev1.Container {
 	return containers
 }
 
-type deployResource struct {
-	containers []containerResources
-	replicas   int32
-}
 type podResource []containerResources
 type containerResources struct {
 	cpu    string

--- a/webhooks/ratio_validator_test.go
+++ b/webhooks/ratio_validator_test.go
@@ -21,6 +21,7 @@ import (
 
 	"testing"
 
+	"github.com/appuio/appuio-cloud-agent/limits"
 	"github.com/appuio/appuio-cloud-agent/ratio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -247,7 +248,7 @@ func TestRatioValidator_Handle(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			v := prepareTest(t, tc.resources...)
 			limit := resource.MustParse(tc.limit)
-			v.RatioLimit = &limit
+			v.RatioLimits = limits.Limits{{Limit: &limit}}
 
 			ar := admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
## Summary

* It is now possible to configure differing ratios for different node selectors

```yaml
MemoryPerCoreLimits:
- Limit: 4Gi
  NodeSelector:
    matchExpressions:
      - key: class
        operator: DoesNotExist
- Limit: 4Gi
  NodeSelector:
    matchExpressions:
      - key: class
        operator: In
        values: [plus]
- Limit: 3Gi
  NodeSelector:
    matchExpressions:
      - key: class
        operator: In
        values: [flex]
```

* Both `RatioValidator` and  `RatioReconciler` have expanded support for this.
* `RatioValidator` added fuzzy matching for existing rations and fetching default node selectors from namespace.
  * Fuzzy matching is required since the scheduler may add more node selectors later.
    Concretely `node-role.kubernetes.io/app: ""`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
