### PR TITLE
Add support for omitting RBAC rules on organization namespaces

### DIFF
--- a/controllers/org_rbac_controller.go
+++ b/controllers/org_rbac_controller.go
@@ -60,7 +60,7 @@ func (r *OrganizationRBACReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	if r.getLabel(ns, LabelNsNoRBAC) == "true" {
+	if r.skipRBACManagement(ns) {
 		return ctrl.Result{}, nil
 	}
 
@@ -85,13 +85,14 @@ func (r *OrganizationRBACReconciler) getOrganization(ns corev1.Namespace) string
 	return org
 }
 
-func (r *OrganizationRBACReconciler) getLabel(ns corev1.Namespace, labelKey string) string {
+func (r *OrganizationRBACReconciler) skipRBACManagement(ns corev1.Namespace) bool {
 	label := ""
 	nsLabels := ns.Labels
 	if nsLabels != nil {
-		label = nsLabels[labelKey]
+		label = nsLabels[LabelNsNoRBAC]
 	}
-	return label
+	result, err := strconv.ParseBool(label)
+	return err == nil && result
 }
 
 func (r *OrganizationRBACReconciler) putRoleBinding(ctx context.Context, ns corev1.Namespace, name string, clusterRole string, group string) error {

--- a/controllers/org_rbac_controller.go
+++ b/controllers/org_rbac_controller.go
@@ -57,11 +57,13 @@ func (r *OrganizationRBACReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	var errs []error
-	for rb, cr := range r.DefaultClusterRoles {
-		if err := r.putRoleBinding(ctx, ns, rb, cr, org); err != nil {
-			l.WithValues("rolebinding", rb).Error(err, "unable to create rolebinding")
-			r.Recorder.Eventf(&ns, "Warning", "RoleBindingCreationFailed", "Failed to create rolebinding %q", rb)
-			errs = append(errs, err)
+	if _, nsNoAccess := ns.Labels["appuio.io/no-access"]; !nsNoAccess {
+		for rb, cr := range r.DefaultClusterRoles {
+			if err := r.putRoleBinding(ctx, ns, rb, cr, org); err != nil {
+				l.WithValues("rolebinding", rb).Error(err, "unable to create rolebinding")
+				r.Recorder.Eventf(&ns, "Warning", "RoleBindingCreationFailed", "Failed to create rolebinding %q", rb)
+				errs = append(errs, err)
+			}
 		}
 	}
 	return ctrl.Result{}, multierr.Combine(errs...)

--- a/controllers/org_rbac_controller.go
+++ b/controllers/org_rbac_controller.go
@@ -33,9 +33,9 @@ type OrganizationRBACReconciler struct {
 // In that case the controller will update it to bind to the organization.
 const LabelRoleBindingUninitialized = "appuio.io/uninitialized"
 
-// LabelNsNoRBAC is used to speficy if RBAC rules should be created for a namespace.
+// LabelNamespaceNoRBAC is used to speficy if RBAC rules should be created for a namespace.
 // If not specified it defaults to `admin` privileges on the namespace owned by the organization
-const LabelNsNoRBAC = "appuio.io/no-rbac-creation"
+const LabelNamespaceNoRBAC = "appuio.io/no-rbac-creation"
 
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;patch;update
@@ -89,7 +89,7 @@ func (r *OrganizationRBACReconciler) skipRBACManagement(ns corev1.Namespace) boo
 	label := ""
 	nsLabels := ns.Labels
 	if nsLabels != nil {
-		label = nsLabels[LabelNsNoRBAC]
+		label = nsLabels[LabelNamespaceNoRBAC]
 	}
 	result, err := strconv.ParseBool(label)
 	return err == nil && result

--- a/controllers/org_rbac_controller_test.go
+++ b/controllers/org_rbac_controller_test.go
@@ -74,6 +74,14 @@ func TestOrganizationRBACReconciler(t *testing.T) {
 				orgLabel: "",
 			},
 		},
+		"NoAccessOrgNs": {
+			clusterRoles: defaultCRs,
+			namespace:    "buzz",
+			nsLabels: map[string]string{
+				"appuio.io/no-access": "",
+				orgLabel:              "foo",
+			},
+		},
 
 		"OrgNs_CreateRole": {
 			clusterRoles: defaultCRs,

--- a/controllers/org_rbac_controller_test.go
+++ b/controllers/org_rbac_controller_test.go
@@ -78,8 +78,8 @@ func TestOrganizationRBACReconciler(t *testing.T) {
 			clusterRoles: defaultCRs,
 			namespace:    "buzz",
 			nsLabels: map[string]string{
-				"appuio.io/no-access": "true",
-				orgLabel:              "foo",
+				"appuio.io/no-rbac-creation": "true",
+				orgLabel:                     "foo",
 			},
 		},
 

--- a/controllers/org_rbac_controller_test.go
+++ b/controllers/org_rbac_controller_test.go
@@ -82,6 +82,22 @@ func TestOrganizationRBACReconciler(t *testing.T) {
 				orgLabel:                     "foo",
 			},
 		},
+		"NoRbacCreationFalseOrgNs_CreateRole": {
+			clusterRoles: defaultCRs,
+			namespace:    "buzz",
+			nsLabels: map[string]string{
+				"appuio.io/no-rbac-creation": "false",
+				orgLabel:                     "foo",
+			},
+
+			expected: []rb{
+				{
+					name:    "admin",
+					roleRef: "admin",
+					groups:  []string{"foo"},
+				},
+			},
+		},
 
 		"OrgNs_CreateRole": {
 			clusterRoles: defaultCRs,

--- a/controllers/org_rbac_controller_test.go
+++ b/controllers/org_rbac_controller_test.go
@@ -78,7 +78,7 @@ func TestOrganizationRBACReconciler(t *testing.T) {
 			clusterRoles: defaultCRs,
 			namespace:    "buzz",
 			nsLabels: map[string]string{
-				"appuio.io/no-access": "",
+				"appuio.io/no-access": "true",
 				orgLabel:              "foo",
 			},
 		},


### PR DESCRIPTION
## Summary

Add a new label `appuio.io/no-access` for the namespace to control the creation of RBAC rules.
If the label has the value  `true`, the controller will not create any RBAC rules for that namespace.

This feature is required for the "Managed by VSHN" AppCat services. The RBAC rules for the managed namespaces should be handled by crossplane and not the controller.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
