### PR TITLE
Fix `*.user.openshift.io` RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,18 +80,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - group.openshift.io
-  resources:
-  - users
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
@@ -105,6 +93,18 @@ rules:
   - rolebindings
   verbs:
   - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/groupsync_controller.go
+++ b/controllers/groupsync_controller.go
@@ -40,7 +40,7 @@ const OrganizationMembersManifestName = "members"
 
 const UpstreamFinalizerPrefix = "agent.appuio.io/group-zone-"
 
-//+kubebuilder:rbac:groups=group.openshift.io,resources=users,verbs=get;list;watch;update;patch;create;delete
+//+kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;update;patch;create;delete
 
 // Reconcile syncs the Group with the upstream OrganizationMembers or Team resource from the foreign (Control-API) cluster.
 func (r *GroupSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Was not noticed because usage profiles require elevated permissions.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
