### PR TITLE
Always validate Namespace and ProjectRequest organization label

### DIFF
--- a/main.go
+++ b/main.go
@@ -229,10 +229,9 @@ func main() {
 			Client:  mgr.GetClient(),
 			Decoder: admission.NewDecoder(mgr.GetScheme()),
 
-			Skipper: skipper.NewMultiSkipper(
-				skipper.StaticSkipper{ShouldSkip: disableUsageProfiles},
-				psk,
-			),
+			Skipper: psk,
+
+			SkipValidateQuota: disableUsageProfiles,
 
 			OrganizationLabel:                 conf.OrganizationLabel,
 			UserDefaultOrganizationAnnotation: conf.UserDefaultOrganizationAnnotation,


### PR DESCRIPTION
The ProjectRequest validation in Kyverno does not work for unknown reasons. This fixes users without default organizations allowed to create projects.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
