### PR TITLE
Don't reconcile RBAC for namespaces in deletion

### DIFF
--- a/controllers/org_rbac_controller.go
+++ b/controllers/org_rbac_controller.go
@@ -55,6 +55,11 @@ func (r *OrganizationRBACReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if ns.DeletionTimestamp != nil {
+		l.Info("namespace is being deleted, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	org := r.getOrganization(ns)
 	if org == "" {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
No big impact. Just ugly error logs.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
