### PR TITLE
Implement legacy namespace quota mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	// AllowedLabels is a list of labels that are allowed on namespaces.
 	// Supports '*' and '?' wildcards.
 	AllowedLabels []string
+
+	// LegacyNamespaceQuota is the default quota for namespaces if no ZoneUsageProfile is selected.
+	LegacyNamespaceQuota int
 }
 
 func ConfigFromFile(path string) (c Config, warn []string, err error) {

--- a/main.go
+++ b/main.go
@@ -248,6 +248,8 @@ func main() {
 
 			SelectedProfile:        selectedUsageProfile,
 			QuotaOverrideNamespace: conf.QuotaOverrideNamespace,
+
+			LegacyNamespaceQuota: conf.LegacyNamespaceQuota,
 		},
 	})
 


### PR DESCRIPTION
Replaces https://hub.syn.tools/appuio-cloud/references/policies/12_namespace_quota_per_zone.html if usage profiles are disabled.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
