### PR TITLE
Never skip `Project` requests

### DIFF
--- a/webhooks/namespace_project_organization_mutator_test.go
+++ b/webhooks/namespace_project_organization_mutator_test.go
@@ -32,6 +32,8 @@ func Test_NamespaceProjectOrganizationMutator_Handle(t *testing.T) {
 
 		allowed  bool
 		orgPatch string
+
+		skip bool
 	}{
 		{
 			name: "Project: request with org label set",
@@ -108,6 +110,21 @@ func Test_NamespaceProjectOrganizationMutator_Handle(t *testing.T) {
 				}
 			},
 
+			user:    "user",
+			allowed: false,
+		},
+		{
+			name: "Project: project requests should not be skipped",
+
+			object: newProjectRequest("project", map[string]string{orgLabel: "other-org"}, nil),
+			additionalObjects: func(*testing.T) []client.Object {
+				return []client.Object{
+					newUser("user", ""),
+					newGroup("other-org"),
+				}
+			},
+
+			skip:    true,
 			user:    "user",
 			allowed: false,
 		},
@@ -358,7 +375,7 @@ func Test_NamespaceProjectOrganizationMutator_Handle(t *testing.T) {
 			subject := NamespaceProjectOrganizationMutator{
 				Decoder: decoder,
 				Client:  c,
-				Skipper: skipper.StaticSkipper{},
+				Skipper: skipper.StaticSkipper{ShouldSkip: tc.skip},
 
 				OrganizationLabel:                 orgLabel,
 				UserDefaultOrganizationAnnotation: testDefaultOrgAnnotation,


### PR DESCRIPTION
The requests comes from internal components of OpenShift, but has an annotation with the original user name.

The user from the annotation is checked later.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
