### PR TITLE
Allow enabling legacy namespace quota independent of usage profiles

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,9 @@ func main() {
 	var namespaceMetadataValidatorEnabled bool
 	flag.BoolVar(&namespaceMetadataValidatorEnabled, "namespace-metadata-validator-enabled", false, "Enable the NamespaceMetadataValidator webhook. Validates the metadata of a namespace.")
 
+	var legacyNamespaceQuotaEnabled bool
+	flag.BoolVar(&legacyNamespaceQuotaEnabled, "legacy-namespace-quota-enabled", false, "Enable the legacy namespace quota controller. This controller is deprecated and will be removed in the future.")
+
 	var qps, burst int
 	flag.IntVar(&qps, "qps", 20, "QPS to use for the controller-runtime client")
 	flag.IntVar(&burst, "burst", 100, "Burst to use for the controller-runtime client")
@@ -241,7 +244,7 @@ func main() {
 
 			Skipper: psk,
 
-			SkipValidateQuota: disableUsageProfiles,
+			SkipValidateQuota: disableUsageProfiles && !legacyNamespaceQuotaEnabled,
 
 			OrganizationLabel:                 conf.OrganizationLabel,
 			UserDefaultOrganizationAnnotation: conf.UserDefaultOrganizationAnnotation,
@@ -249,7 +252,8 @@ func main() {
 			SelectedProfile:        selectedUsageProfile,
 			QuotaOverrideNamespace: conf.QuotaOverrideNamespace,
 
-			LegacyNamespaceQuota: conf.LegacyNamespaceQuota,
+			EnableLegacyNamespaceQuota: legacyNamespaceQuotaEnabled,
+			LegacyNamespaceQuota:       conf.LegacyNamespaceQuota,
 		},
 	})
 

--- a/webhooks/namespace_quota_validator_test.go
+++ b/webhooks/namespace_quota_validator_test.go
@@ -344,6 +344,9 @@ func TestNamespaceQuotaValidator_Handle(t *testing.T) {
 				LegacyNamespaceQuota:   test.legacyQuota,
 			}
 
+			if test.legacyQuota > 0 {
+				subject.EnableLegacyNamespaceQuota = true
+			}
 			if test.disableProfile {
 				subject.SelectedProfile = ""
 			}


### PR DESCRIPTION
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
