### PR TITLE
Add missing permissions to list/update zones in foreign_rbac Kustomization

### DIFF
--- a/config/foreign_rbac/role.yaml
+++ b/config/foreign_rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - users
   - teams
   - organizationmembers
+  - zones
   verbs:
   - get
   - list
@@ -23,6 +24,7 @@ rules:
   - teams/finalizers
   - organizationmembers
   - organizationmembers/finalizers
+  - zones
   verbs:
   - update
   - patch


### PR DESCRIPTION
## Summary

* Add `zones` in foreign RBAC Kustomization ClusterRole

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
